### PR TITLE
feat(manifest): add entitlement to enable tracking API

### DIFF
--- a/manifest.lkml
+++ b/manifest.lkml
@@ -5,6 +5,7 @@ application: ask_looker {
   url: "https://static-a.lookercdn.com/extensions/lqa/master/bundle.js"
   entitlements: {
     local_storage: yes
+    use_tracking_api: yes
     scoped_user_attributes: ["last_selected_topic"]
     core_api_methods: [
       "all_lookml_models",


### PR DESCRIPTION
Depends on https://github.com/looker/helltool/pull/62796 that enables tracking api through the manifest entitlement.